### PR TITLE
#285 Replace references to jupyter-incubator with jupyter for dashboards only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## 0.6.0 (2016-06-17)
 
-* Switch to the [v1 dashboard layout specification](https://github.com/jupyter-incubator/dashboards/wiki/Dashboard-Metadata-and-Rendering)
+* Switch to the [v1 dashboard layout specification](https://github.com/jupyter/dashboards/wiki/Dashboard-Metadata-and-Rendering)
 * Automatically upgrade existing notebook metadata to the v1 spec
 * Update example notebooks for compatibility with `jupyter_declarativewidgets` 0.6.0
 * Remove `urth` moniker in favor of `jupyter_dashboards` for CSS classes, notebook metadata, etc.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jupyter Dashboards - Layout Extension
 
-[![PyPI version](https://badge.fury.io/py/jupyter_dashboards.svg)](https://badge.fury.io/py/jupyter_dashboards) [![Build Status](https://travis-ci.org/jupyter-incubator/dashboards.svg?branch=master)](https://travis-ci.org/jupyter-incubator/dashboards) [![Google Group](https://img.shields.io/badge/-Google%20Group-lightgrey.svg)](https://groups.google.com/forum/#!forum/jupyter)
+[![PyPI version](https://badge.fury.io/py/jupyter_dashboards.svg)](https://badge.fury.io/py/jupyter_dashboards) [![Build Status](https://travis-ci.org/jupyter/dashboards.svg?branch=master)](https://travis-ci.org/jupyter/dashboards) [![Google Group](https://img.shields.io/badge/-Google%20Group-lightgrey.svg)](https://groups.google.com/forum/#!forum/jupyter)
 
 ## Overview
 

--- a/docs/source/development.md
+++ b/docs/source/development.md
@@ -12,7 +12,7 @@ mkdir -p ~/projects
 cd !$
 
 # clone this repo
-git clone https://github.com/jupyter-incubator/dashboards.git
+git clone https://github.com/jupyter/dashboards.git
 ```
 
 Pull a base Docker image and build a subimage from it that includes `bower`, `nodejs`, and `npm` both as a dashboard dev dependency and as a prereq for example notebooks that use declarative widgets.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,7 +14,7 @@ The extension is part of the larger Jupyter Dashboards effort which covers:
 
 The layout extension focuses on (1) above, while `jupyter-incubator/dashboards_bundlers <https://github.com/jupyter-incubator/dashboards_bundlers>`_ handles (2) and `jupyter-incubator/dashboards_server <https://github.com/jupyter-incubator/dashboards_server>`_ implements (3).
 
-For a sample of what's possible with the dashboard layout extension, have a look at the `demo dashboard-notebooks in the project repository <https://github.com/jupyter-incubator/dashboards/tree/master/etc/notebooks>`__.
+For a sample of what's possible with the dashboard layout extension, have a look at the `demo dashboard-notebooks in the project repository <https://github.com/jupyter/dashboards/tree/master/etc/notebooks>`__.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/metadata.md
+++ b/docs/source/metadata.md
@@ -2,14 +2,14 @@
 
 This page documents:
 
-1. The fields written to notebook documents (`.ipynb` files) by the `jupyter-incubator/dashboards` extension
-2. The interpretation of these fields in `jupyter-incubator/dashboards` and `jupyter-incubator/dashboards_server` to render a notebook in a dashboard layout.
+1. The fields written to notebook documents (`.ipynb` files) by the `jupyter/dashboards` extension
+2. The interpretation of these fields in `jupyter/dashboards` and `jupyter-incubator/dashboards_server` to render a notebook in a dashboard layout.
 
 ## Versioning
 
 The dashboard metadata specification is versioned independently of the packages that use it. The current version of the specification is v1. 
 
-Prior to the v1 specification, the dashboard incubator projects read and wrote a legacy v0 metadata format. The details of this [older spec appear on the dashboards wiki](https://github.com/jupyter-incubator/dashboards/wiki/Dashboard-Metadata-and-Rendering#spec-v0) for historical purposes.
+Prior to the v1 specification, the dashboard incubator projects read and wrote a legacy v0 metadata format. The details of this [older spec appear on the dashboards wiki](https://github.com/jupyter/dashboards/wiki/Dashboard-Metadata-and-Rendering#spec-v0) for historical purposes.
 
 ## Notebook Fields
 

--- a/docs/source/summary-changes.md
+++ b/docs/source/summary-changes.md
@@ -6,7 +6,7 @@ See `git log` for a more detailed summary of changes.
 
 ### 0.6.0 (2016-06-17)
 
-* Switch to the [v1 dashboard layout specification](https://github.com/jupyter-incubator/dashboards/wiki/Dashboard-Metadata-and-Rendering)
+* Switch to the [v1 dashboard layout specification](https://github.com/jupyter/dashboards/wiki/Dashboard-Metadata-and-Rendering)
 * Automatically upgrade existing notebook metadata to the v1 spec
 * Update example notebooks for compatibility with `jupyter_declarativewidgets` 0.6.0
 * Remove `urth` moniker in favor of `jupyter_dashboards` for CSS classes, notebook metadata, etc.

--- a/etc/notebooks/index.ipynb
+++ b/etc/notebooks/index.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "# Dynamic Dashboards Quick Start Guide\n",
     "\n",
-    "[Dynamic Dashboards](https://github.com/jupyter-incubator/dashboards) allow us to quickly create a functional application with minimal effort using a notebook. The notebook cell outputs become the components of the dashboard and can be moved, resized, and hidden as desired. Other technologies, both server- and client-side, can be used to enhance the Dashboard experience. This notebook will give you a quick overview of how to use Dynamic Dashboards. For more detailed information, see the [wiki](https://github.com/jupyter-incubator/dashboards/wiki).\n",
+    "[Dynamic Dashboards](https://github.com/jupyter/dashboards) allow us to quickly create a functional application with minimal effort using a notebook. The notebook cell outputs become the components of the dashboard and can be moved, resized, and hidden as desired. Other technologies, both server- and client-side, can be used to enhance the Dashboard experience. This notebook will give you a quick overview of how to use Dynamic Dashboards. For more detailed information, see the [wiki](https://github.com/jupyter/dashboards/wiki).\n",
     "\n",
     "## Creating a Dashboard\n",
     "\n",
@@ -36,7 +36,7 @@
     "\n",
     "To return to the Notebook, use either the **Dashboard View** toolbar buttons or the **View > Notebook** menu item.\n",
     "\n",
-    "As a final step, you can download or deploy your dashboard. These depend on other components from the Jupyter ecosystem. See the [wiki](https://github.com/jupyter-incubator/dashboards/wiki) for details.\n",
+    "As a final step, you can download or deploy your dashboard. These depend on other components from the Jupyter ecosystem. See the [wiki](https://github.com/jupyter/dashboards/wiki) for details.\n",
     "\n",
     "### Dashboard Layouts\n",
     "\n",

--- a/etc/notebooks/resizable_widgets_tutorial/resizable_widgets.ipynb
+++ b/etc/notebooks/resizable_widgets_tutorial/resizable_widgets.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "# Resizable Widget Tutorial\n",
     "\n",
-    "This tutorial demonstrates how to implement a resizable Polymer element for use with the [Dynamic Dashboard](https://github.com/jupyter-incubator/dashboards) extension. By using [`iron-resizable-behavior`](https://elements.polymer-project.org/elements/iron-resizable-behavior?active=Polymer.IronResizableBehavior), your widget can be informed when it is resized, allowing you to act accordingly. This is mainly applicable to [Declarative Widgets](https://github.com/jupyter-incubator/declarativewidgets) as a declarative widget is a Polymer element.\n",
+    "This tutorial demonstrates how to implement a resizable Polymer element for use with the [Dynamic Dashboard](https://github.com/jupyter/dashboards) extension. By using [`iron-resizable-behavior`](https://elements.polymer-project.org/elements/iron-resizable-behavior?active=Polymer.IronResizableBehavior), your widget can be informed when it is resized, allowing you to act accordingly. This is mainly applicable to [Declarative Widgets](https://github.com/jupyter-incubator/declarativewidgets) as a declarative widget is a Polymer element.\n",
     "\n",
     "A Notebook cell can be resized in one of two ways: (1) by resizing the window or (2) by resizing the cell when in the Dashboard layout view (`View > Layout Dashboard`). Any cell output content is responsible for sizing itself. By listening to the `iron-resize` event, your widget can be notified of both of these resize actions.\n",
     "\n",

--- a/jupyter_dashboards/nbextension/notebook/dashboard-view/dashboard-metadata-compatibility.js
+++ b/jupyter_dashboards/nbextension/notebook/dashboard-view/dashboard-metadata-compatibility.js
@@ -7,7 +7,7 @@
  * Jupyter Dashboards extension metadata.
  *
  * Jupyter Dashboard metadata structure:
- *    https://github.com/jupyter-incubator/dashboards/wiki/Dashboard-Metadata-and-Rendering
+ *    https://github.com/jupyter/dashboards/wiki/Dashboard-Metadata-and-Rendering
  */
 define([
     'jquery',

--- a/jupyter_dashboards/nbextension/notebook/dashboard-view/dashboard-metadata.js
+++ b/jupyter_dashboards/nbextension/notebook/dashboard-view/dashboard-metadata.js
@@ -6,7 +6,7 @@
  * This module provides an API to manage Jupyter Dashboards extension metadata.
  *
  * Jupyter Dashboard metadata structure:
- *    https://github.com/jupyter-incubator/dashboards/wiki/Dashboard-Metadata-and-Rendering
+ *    https://github.com/jupyter/dashboards/wiki/Dashboard-Metadata-and-Rendering
  */
 define([
     'jquery',

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyter-incubator/dashboards.git"
+    "url": "https://github.com/jupyter/dashboards.git"
   },
   "keywords": [
     "ipython",

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,10 @@ setup_args = dict(
 * Dashboard view mode for interacting with an assembled dashboard within the Jupyter Notebook
 * Ability to share notebooks with dashboard layout metadata in them with other Jupyter Notebook users
 
-See `the project README <https://github.com/jupyter-incubator/dashboards>`_
+See `the project README <https://github.com/jupyter/dashboards>`_
 for more information.
 ''',
-    url='https://github.com/jupyter-incubator/dashboards',
+    url='https://github.com/jupyter/dashboards',
     version=VERSION_NS['__version__'],
     license='BSD',
     platforms=['Jupyter Notebook 4.0.x', 'Jupyter Notebook 4.1.x', 'Jupyter Notebook 4.2.x'],


### PR DESCRIPTION
See #285 

The `dashboards` repo has been migrated from `jupyter-incubator` organization to `jupyter`. Make appropriate changes in documentation and strings.