### PR TITLE
Fix #283: Clip at grid cell boundaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ env: ## Make a dev environment
 js: ## Make JavaScript assets
 	npm install
 	npm run bower
+	$(SA) $(ENV) && \
+		pip install -e . && \
+		jupyter dashboards quick-setup --sys-prefix
 
 notebook: ## Make a notebook server
 	$(SA) $(ENV) && jupyter notebook --notebook-dir=./etc/notebooks

--- a/jupyter_dashboards/nbextension/notebook/dashboard-common/dashboard-common.css
+++ b/jupyter_dashboards/nbextension/notebook/dashboard-common/dashboard-common.css
@@ -9,7 +9,7 @@
 
 .jupyter-dashboard .container div.output_subarea {
     max-width: 100%; /* override Notebook CSS so it takes up full width */
-    overflow: visible; /* ensure contents overflow, needed for widgets such as dropdown menus */
+    overflow: hidden; /* hide overflowing contents */
 }
 
 /* disable display of paragraph anchor text*/


### PR DESCRIPTION
Comment in file said overflow was done to allow popover widgets
to display properly. When I change the styling, both ipwidget
and declarative widget popover still appear to show properly
in my limited test. Other content clips at the dashboard cell
boundaries, as expected and desired.